### PR TITLE
Update formspree URL

### DIFF
--- a/js/openinfra.js
+++ b/js/openinfra.js
@@ -33,7 +33,7 @@ $(function() {
                 firstName = name.split(' ').slice(0, -1).join(' ');
             }
             $.ajax({
-                url: "//formspree.io/info+website@openinfrastructure.co",
+                url: "//formspree.io/f/xayzqnpq",
                 type: "POST",
                 data: {
                     name: name,


### PR DESCRIPTION
The contact form wasn't working, and was returning the following error
message:

```
{"error":"In order to submit via AJAX, reCAPTCHA must be disabled in
this form's settings page."}
```

To fix that, we've updated the formspree URL to point to a form that
doesn't have the reCAPTCHA enabled.
