### PR TITLE
Introduce a "successes" section

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -12,27 +12,14 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav navbar-right">
-        <li class="hidden">
-          <a href="#page-top"></a>
-        </li>
-        <li>
-          <a href="/news/">News</a>
-        </li>
-        <li>
-          <a href="/news/archive/">Archive</a>
-        </li>
-        <li>
-          <a class="page-scroll" href="/#services">Services</a>
-        </li>
-        <li>
-          <a class="page-scroll" href="/puppet/">Puppet Consulting</a>
-        </li>
-        <li>
-          <a class="page-scroll" href="/#about">About</a>
-        </li>
-        <li>
-          <a class="page-scroll" href="/#contact">Contact</a>
-        </li>
+        <li class="hidden"><a href="#page-top"></a></li>
+        <li><a href="/#about" class="page-scroll">About</a></li>
+        <li><a href="/news/">News</a></li>
+        <li><a href="/#services" class="page-scroll">Services</a></li>
+        <li><a href="/puppet/" class="page-scroll">Puppet Consulting</a></li>
+        <li><a href="/successes/" class="page-scroll">Successes</a></li>
+        <li><a href="/news/archive/">Archive</a></li>
+        <li><a href="/#contact" class="page-scroll">Contact</a></li>
       </ul>
     </div>
     <!-- /.navbar-collapse -->

--- a/puppet.html
+++ b/puppet.html
@@ -87,23 +87,6 @@ author: jeff
   </div>
 </section>
 
-<section id="testimonials">
-  <div class="container">
-    <div class="row text-center">
-      <div class="col-lg-12">
-        <h2 class="section-heading">Testimonials</h2>
-        <p class="text-muted">
-          <i>"[Open Infrastructure Services, LLC] helped Twitter successfully perform a
-          complete overhaul of its production configuration management system.
-          The impact is that Twitter site incidents attributed to
-          configuration changes, once a regular occurrence, have been
-          virtually eliminated, with zero observed for one year as of
-          September 2022."</i> - <b>Patrick Newman, Sr. Engineering Manager, Core Infrastructure Services SRE @ Twitter, 2019-2022</b>
-      </div>
-    </div>
-  </div>
-</section>
-
 <!-- Contact Section -->
 <section id="contact">
   <div class="container">

--- a/successes.md
+++ b/successes.md
@@ -1,0 +1,36 @@
+---
+layout: singlepage
+description: "Success Stories and Testimonials"
+author: jeff
+---
+
+<div markdown="1" class="container">
+<h2 class="section-heading text-center">Recent Successes</h2>
+<h3 class="section-subheading text-center text-muted">Twitter</h3>
+
+Developed a solution for incrementally applying Puppet code changes across scheduled failure domains (Puppet IC).
+
+* IC functions as a feature-flag workflow in the Puppet DSL, allowing for pausing or rolling back individual changes.
+* IC reduced Puppet-related site incidents from multiple per-quarter to zero per year following its release.
+
+Developed a solution for automated canary analysis of Puppet code changes.
+
+* Puppet code changes causing an increase in errors are automatically paused using the IC workflow.
+* Code changes that would normally result in site incidents are instead confined to a blast radius of 1% of the fleet.
+
+Optimized Puppetserver infrastructure resulting in a ~50% reduction in server costs while improving performance.
+
+* Developed a caching layer that, combined with configuration tuning, resulted in the elimination of Puppetserver death spirals.
+* Developed a Systemd-based solution for running multiple Puppetserver processes on a bare-metal host.
+
+Developed a cloud-based visibilty solution for tracking Puppet resource changes at a scale of millions per-day.
+
+<h2 class="section-heading text-center">Testimonials</h2>
+
+_"[Open Infrastructure Services, LLC] helped Twitter successfully perform a
+complete overhaul of its production configuration management system.
+The impact is that Twitter site incidents attributed to
+configuration changes, once a regular occurrence, have been
+virtually eliminated, with zero observed for one year as of
+September 2022."_ - __Patrick Newman, Sr. Engineering Manager, Core Infrastructure Services SRE @ Twitter, 2019-2022__
+</div>


### PR DESCRIPTION
This commit introduces a "successes" section to the Puppet consulting
page that allows us to detail the specific successes we've had with past
customers.
