### PR TITLE
Reduce white space between sections and headers

### DIFF
--- a/css/openinfra.css
+++ b/css/openinfra.css
@@ -104,7 +104,7 @@ hr.small {
   -moz-background-size: cover;
   background-size: cover;
   -o-background-size: cover;
-  margin-bottom: 50px;
+  margin-bottom: 10px;
 }
 .intro-header .site-heading,
 .intro-header .post-heading,
@@ -213,11 +213,11 @@ hr.small {
   }
 }
 section {
-  padding: 80px 0;
+  padding: 5px;
 }
 .section-heading {
   font-size: 36px;
-  margin-top: 60px;
+  margin-top: 40px;
   font-weight: 700;
 }
 .caption {


### PR DESCRIPTION
This reduces the whitespace between sections within a page and at the bottom of the header section.

The goal is to make more of the page visible in a standard-sized browser window and not have to scroll down too much to see page contents.


Refer to https://www.w3schools.com/css/css_padding.asp to understand `margin` and `padding` values.